### PR TITLE
Fix: Relocate KeyboardAvoidingView to screen level

### DIFF
--- a/src/components/Composer.js
+++ b/src/components/Composer.js
@@ -7,9 +7,9 @@ import {
   ActivityIndicator,
   StyleSheet,
   Platform,
-  KeyboardAvoidingView,
-  TouchableWithoutFeedback,
-  Keyboard,
+  // KeyboardAvoidingView, // Removed
+  // TouchableWithoutFeedback, // Removed
+  // Keyboard, // Removed
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme, spacing, typography } from '../utils/theme';
@@ -27,17 +27,13 @@ export default function Composer({
 
   const canSend = value.trim().length > 0 && !loading;
 
+  // No KeyboardAvoidingView wrapper needed here
+  // No TouchableWithoutFeedback wrapper needed here
   return (
-    <KeyboardAvoidingView
-      style={styles.wrapper}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 0}
-    >
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-        <View style={styles.composerContainer}>
-          <View style={styles.inputContainer}>
-            <TextInput
-              style={styles.promptInput}
+    <View style={styles.composerContainer}>
+      <View style={styles.inputContainer}>
+        <TextInput
+          style={styles.promptInput}
               placeholder={placeholder}
               placeholderTextColor={colors.subtext}
               multiline
@@ -59,16 +55,12 @@ export default function Composer({
             </TouchableOpacity>
           </View>
         </View>
-      </TouchableWithoutFeedback>
-    </KeyboardAvoidingView>
   );
 }
 
 const getStyles = (theme) =>
   StyleSheet.create({
-    wrapper: {
-      width: '100%',
-    },
+    // wrapper style is no longer needed
     composerContainer: {
       padding: spacing.md,
       backgroundColor: theme.colors.background,

--- a/src/screens/ChatThread.js
+++ b/src/screens/ChatThread.js
@@ -4,7 +4,7 @@ import React, { useState, useRef, useEffect, useContext, useCallback, useMemo } 
 import {
   StyleSheet, Text, View, FlatList,
   Platform, Keyboard, Linking, Pressable, Clipboard, Alert, ToastAndroid,
-  ActivityIndicator, Image, TouchableOpacity, LayoutAnimation, UIManager
+  ActivityIndicator, Image, TouchableOpacity, LayoutAnimation, UIManager, KeyboardAvoidingView // Added
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Markdown from 'react-native-markdown-display';
@@ -462,7 +462,11 @@ ${agentInstructions}
         <Text style={styles.chatTitle} numberOfLines={1}>{thread.name}</Text>
         <View style={{ width: 40 }} />
       </View>
-      <View style={{flex: 1}}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        style={{ flex: 1 }}
+        keyboardVerticalOffset={CHAT_HEADER_HEIGHT}
+      >
         <FlatList
           style={{ flex: 1 }}
           ref={listRef}
@@ -482,7 +486,7 @@ ${agentInstructions}
           loading={loading}
           placeholder={currentCharacter ? `Chat with ${currentCharacter.name}...` : "Type a message..."}
         />
-      </View>
+      </KeyboardAvoidingView>
     </SafeAreaView>
   );
 }

--- a/src/screens/ImageGenerationScreen.js
+++ b/src/screens/ImageGenerationScreen.js
@@ -11,6 +11,7 @@ import {
     Platform,
     StatusBar,
     Keyboard,
+    KeyboardAvoidingView, // Added
     UIManager,
     Image as RNImage,
     Modal,
@@ -202,9 +203,11 @@ export default function ImageGenerationScreen({ navigation }) {
             <StatusBar barStyle={scheme === 'dark' ? 'light-content' : 'dark-content'} backgroundColor={colors.background} />
             <ImageGalleryModal visible={modalVisible} images={urls} initialIndex={startIndex} onClose={() => setModalVisible(false)} />
             <ScreenHeader title="Image Studio" navigation={navigation} subtitle="Craft your vision with AI" />
-            {/* Screen-level KAV removed, Composer's KAV will handle the input area.
-                The main content area is wrapped in a View to ensure proper flex behavior. */}
-            <View style={{ flex: 1 }}>
+            <KeyboardAvoidingView
+                behavior={Platform.OS === "ios" ? "padding" : "height"}
+                style={{ flex: 1 }}
+                keyboardVerticalOffset={HEADER_HEIGHT} // Use defined HEADER_HEIGHT
+            >
                 <ScrollView
                     style={{ flex: 1 }}
                     contentContainerStyle={styles.scrollContainer}
@@ -249,7 +252,7 @@ export default function ImageGenerationScreen({ navigation }) {
                     loading={anyLoading}
                     placeholder="A majestic dragon soaring through clouds..."
                 />
-            </View>
+            </KeyboardAvoidingView>
         </SafeAreaView>
     );
 }

--- a/src/screens/LanguageTutorScreen.js
+++ b/src/screens/LanguageTutorScreen.js
@@ -11,6 +11,7 @@ import {
   StatusBar,
   Platform,
   Keyboard,
+  KeyboardAvoidingView, // Added
   Alert,
   LayoutAnimation,
   UIManager,
@@ -220,9 +221,11 @@ export default function LanguageTutorScreen({ navigation }) {
     <SafeAreaView style={styles.container} edges={['top', 'left', 'right']}>
       <StatusBar barStyle={scheme === 'dark' ? "light-content" : "dark-content"} backgroundColor={colors.background} />
       <ScreenHeader navigation={navigation} title="Language Lab" subtitle="AI-powered learning assistant" />
-      {/* Screen-level KAV removed, Composer's KAV will handle the input area.
-          The main content area is wrapped in a View to ensure proper flex behavior. */}
-      <View style={{ flex: 1 }}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        style={{ flex: 1 }}
+        keyboardVerticalOffset={HEADER_HEIGHT} // Use defined HEADER_HEIGHT
+      >
         <ScrollView
           style={{ flex: 1 }}
           contentContainerStyle={styles.scrollContainer}
@@ -253,7 +256,7 @@ export default function LanguageTutorScreen({ navigation }) {
           loading={loading}
           placeholder={mode === 'Translate' ? 'Type text...' : 'Ask your tutor...'}
         />
-      </View>
+      </KeyboardAvoidingView>
     </SafeAreaView>
   );
 }


### PR DESCRIPTION
Moved KeyboardAvoidingView from the Composer component to the parent screen level (ChatThread, ImageGenerationScreen, LanguageTutorScreen) to correctly handle keyboard visibility.

This resolves an issue where the input composer was obscured by the keyboard. The Composer component was simplified by removing its internal KeyboardAvoidingView, and each affected screen now manages its own keyboard avoidance behavior, ensuring the input remains visible when the keyboard is active.